### PR TITLE
Optimize fsync latency with fallocate and fadvise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ CTestTestfile.cmake
 
 # Github aciton
 !.github
+
+bld/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(braft C CXX)
 
 SET(CPACK_GENERATOR "DEB")
 SET(CPACK_DEBIAN_PACKAGE_MAINTAINER "braft authors") #required
+SET(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 INCLUDE(CPack)
 
@@ -67,7 +68,7 @@ if(LEVELDB_WITH_SNAPPY)
 endif()
 
 find_path(BRPC_INCLUDE_PATH NAMES brpc/server.h)
-find_library(BRPC_LIB NAMES libbrpc.a brpc)
+find_library(BRPC_LIB NAMES brpc)
 if ((NOT BRPC_INCLUDE_PATH) OR (NOT BRPC_LIB))
     message(FATAL_ERROR "Fail to find brpc")
 endif()

--- a/src/braft/log.cpp
+++ b/src/braft/log.cpp
@@ -111,6 +111,8 @@ int Segment::create() {
     if (_fd >= 0) {
         butil::make_close_on_exec(_fd);
     }
+    fallocate(_fd, FALLOC_FL_ZERO_RANGE, 0, FLAGS_raft_max_segment_size);
+    posix_fadvise(_fd, 0, 0, POSIX_FADV_SEQUENTIAL);
     LOG_IF(INFO, _fd >= 0) << "Created new segment `" << path 
                            << "' with fd=" << _fd ;
     return _fd >= 0 ? 0 : -1;


### PR DESCRIPTION
- Optimize fsync latency with fallocate and fadvise.  
- Link with libbrpc.so by default.

Related to #monographdb/monographdb_engine_for_mongodb/issues/11