### PR TITLE
Add API to clear underling channels in rtb

### DIFF
--- a/src/braft/route_table.cpp
+++ b/src/braft/route_table.cpp
@@ -99,6 +99,11 @@ public:
         return {true, chan};
     }
 
+    void clear_internal_channels() {
+        std::unique_lock<std::mutex> lk(_channel_mux);
+        _channels.clear();
+    }
+
 private:
 friend struct DefaultSingletonTraits<RouteTable>;
     RouteTable() {
@@ -257,6 +262,11 @@ int select_leader(const GroupId& group, PeerId* leader) {
 int remove_group(const GroupId& group) {
     RouteTable* const rtb = RouteTable::GetInstance();
     return rtb->remove_group(group);
+}
+
+void clear_internal_channels() {
+    RouteTable* const rtb = RouteTable::GetInstance();
+    rtb->clear_internal_channels();
 }
 
 }  // namespace rtb

--- a/src/braft/route_table.h
+++ b/src/braft/route_table.h
@@ -46,6 +46,9 @@ butil::Status refresh_leader(const GroupId& group, int timeout_ms);
 // Remove this group from route table
 int remove_group(const GroupId& group);
 
+// Clear underlying channels
+void clear_internal_channels();
+
 }  // namespace rtb
 }  // namespace braft 
 


### PR DESCRIPTION
When host manger detached from TxService, the CcNodeService and LogService are all quit, but those brpc::Channels and the underling Sockets are cached for reuse in the braft::RouteTable by HostManager. When Attach TxService happen, the HostManger will try to reuse the cached Channel to issue RPC to LogService, but failed. So, we need to clear those cached Channels when detach TxService.
