### PR TITLE
Optimize log storage append_entries.

### DIFF
--- a/src/braft/fsync.h
+++ b/src/braft/fsync.h
@@ -31,7 +31,6 @@ DECLARE_bool(raft_use_bthread_fsync);
 
 inline int raft_fsync(int fd) {
     if (FLAGS_raft_use_fsync_rather_than_fdatasync) {
-        auto start = butil::cpuwide_time_us();
         if (FLAGS_raft_use_bthread_fsync) {
             int res = bthread_fsync(fd);
             if (res == -1) {

--- a/src/braft/fsync.h
+++ b/src/braft/fsync.h
@@ -29,24 +29,18 @@ namespace braft {
 DECLARE_bool(raft_use_fsync_rather_than_fdatasync);
 DECLARE_bool(raft_use_bthread_fsync);
 
-inline bvar::LatencyRecorder sync_us("a_", "sync_us");
-
 inline int raft_fsync(int fd) {
     if (FLAGS_raft_use_fsync_rather_than_fdatasync) {
         auto start = butil::cpuwide_time_us();
         if (FLAGS_raft_use_bthread_fsync) {
             int res = bthread_fsync(fd);
             if (res == -1) {
-                // LOG(ERROR) << "bthread_fsync fails, use fsync";
-                res = fsync(fd);
+                return fsync(fd);
             }
-            sync_us << butil::cpuwide_time_us() - start;
             return res;
         }
         else {
-            int res = fsync(fd);
-            sync_us << butil::cpuwide_time_us() - start;
-            return res;
+            return fsync(fd);
         }
     } else {
 #ifdef __APPLE__

--- a/src/braft/log.cpp
+++ b/src/braft/log.cpp
@@ -421,20 +421,12 @@ int Segment::append(const LogEntry* entry) {
     }
     CHECK_LE(data.length(), 1ul << 56ul);
     char header_buf[ENTRY_HEADER_SIZE];
-    // const uint32_t meta_field = (entry->type << 24 ) | (_checksum_type << 16);
-    // RawPacker packer(header_buf);
-    // packer.pack64(entry->id.term)
-    //       .pack32(meta_field)
-    //       .pack32((uint32_t)data.length())
-    //       .pack32(get_checksum(_checksum_type, data));
-    // packer.pack32(get_checksum(
-    //               _checksum_type, header_buf, ENTRY_HEADER_SIZE - 4));
     const uint32_t meta_field = (entry->type << 24 ) | (_checksum_type << 16);
     RawPacker packer(header_buf);
     packer.pack64(entry->id.term)
           .pack32(meta_field)
-          .pack32((uint32_t)entry->data.length())
-          .pack32(get_checksum(_checksum_type, entry->data));
+          .pack32((uint32_t)data.length())
+          .pack32(get_checksum(_checksum_type, data));
     packer.pack32(get_checksum(
                   _checksum_type, header_buf, ENTRY_HEADER_SIZE - 4));
 

--- a/src/braft/log.cpp
+++ b/src/braft/log.cpp
@@ -1424,6 +1424,7 @@ scoped_refptr<Segment> SegmentLogStorage::open_segment() {
                     LOG(ERROR) << "fail to flush segment data";
                     return nullptr;
                 }
+                _last_log_index.fetch_add(ret, butil::memory_order_release);
             }
             if (prev_open_segment->close(_enable_sync) == 0) {
                 BAIDU_SCOPED_LOCK(_mutex);

--- a/src/braft/log.cpp
+++ b/src/braft/log.cpp
@@ -901,7 +901,7 @@ int SegmentLogStorage::append_entries_in_batch(const std::vector<LogEntry*>& ent
             g_open_segment_latency << delta_time_us;
         }
         if (NULL == segment) {
-            return i;
+            return last_success;
         }
         int ret = segment->prepare_data(entry);
         if (0 != ret) {

--- a/src/braft/log.cpp
+++ b/src/braft/log.cpp
@@ -919,7 +919,7 @@ int SegmentLogStorage::append_entries(const std::vector<LogEntry*>& entries, IOM
     return entries.size();
 }
 
-int SegmentLogStorage::append_entries_new(const std::vector<LogEntry*>& entries, IOMetric* metric) {
+int SegmentLogStorage::append_entries_in_batch(const std::vector<LogEntry*>& entries, IOMetric* metric) {
     if (entries.empty()) {
         return 0;
     }

--- a/src/braft/log.cpp
+++ b/src/braft/log.cpp
@@ -412,7 +412,6 @@ int Segment::append(const LogEntry* entry) {
           .pack32(get_checksum(_checksum_type, data));
     packer.pack32(get_checksum(
                   _checksum_type, header_buf, ENTRY_HEADER_SIZE - 4));
-
     butil::IOBuf header;
     header.append(header_buf, ENTRY_HEADER_SIZE);
     const size_t to_write = header.length() + data.length();
@@ -926,7 +925,6 @@ int SegmentLogStorage::append_entries_in_batch(const std::vector<LogEntry*>& ent
     }
     int ret = last_segment->flush_data();
     if (ret < 0) {
-        // LOG(INFO) << "append_entries return: " << last_success;
         return last_success;
     }
     _last_log_index.fetch_add(ret, butil::memory_order_release);

--- a/src/braft/log.cpp
+++ b/src/braft/log.cpp
@@ -531,8 +531,7 @@ int Segment::prepare_data(const LogEntry* entry) {
     _data_list.emplace_back(std::move(head_and_data));
     _pieces[_data_list.size() - 1] = &_data_list.back();
     _to_write += _data_list.back().length();
-
-    _offset_and_term_stashed.push_back(std::make_pair(_bytes, entry->id.term));
+    _offset_and_term_stashed.emplace_back(_bytes, entry->id.term);
 
     return 0;
 }

--- a/src/braft/log.h
+++ b/src/braft/log.h
@@ -104,7 +104,6 @@ private:
 friend class butil::RefCountedThreadSafe<Segment>;
     ~Segment() {
         if (_fd >= 0) {
-            LOG(INFO) << "Segment::~Segment(), close fd: " << _fd;
             ::close(_fd);
             _fd = -1;
         }

--- a/src/braft/log.h
+++ b/src/braft/log.h
@@ -99,6 +99,7 @@ private:
 friend class butil::RefCountedThreadSafe<Segment>;
     ~Segment() {
         if (_fd >= 0) {
+            LOG(INFO) << "Segment::~Segment(), close fd: " << _fd;
             ::close(_fd);
             _fd = -1;
         }

--- a/src/braft/log.h
+++ b/src/braft/log.h
@@ -191,7 +191,7 @@ public:
 
     // append entries to log and update IOMetric, return success append number
     virtual int append_entries(const std::vector<LogEntry*>& entries, IOMetric* metric);
-    virtual int append_entries_new(const std::vector<LogEntry*>& entries, IOMetric* metric);
+    virtual int append_entries_in_batch(const std::vector<LogEntry*>& entries, IOMetric* metric);
 
     // delete logs from storage's head, [1, first_index_kept) will be discarded
     virtual int truncate_prefix(const int64_t first_index_kept);

--- a/src/braft/log.h
+++ b/src/braft/log.h
@@ -59,6 +59,11 @@ public:
 
     // serialize entry, and append to open segment
     int append(const LogEntry* entry);
+    int prepare_data(const LogEntry* entry);
+
+    bool buffer_full() const;
+    bool need_flush() const;
+    int flush_data();
 
     // get entry by index
     LogEntry* get(const int64_t index) const;
@@ -83,7 +88,7 @@ public:
     }
 
     int64_t bytes() const {
-        return _bytes;
+        return _bytes + _to_write;
     }
 
     int64_t first_index() const {
@@ -128,6 +133,12 @@ friend class butil::RefCountedThreadSafe<Segment>;
     butil::atomic<int64_t> _last_index;
     int _checksum_type;
     std::vector<std::pair<int64_t/*offset*/, int64_t/*term*/> > _offset_and_term;
+    std::vector<std::pair<int64_t/*offset*/, int64_t/*term*/> > _offset_and_term_stashed;
+
+    size_t _to_write{};
+    std::vector<butil::IOBuf> _data_list;
+    // TODO(zkl): use vector
+    butil::IOBuf *_pieces[1024];
 };
 
 // LogStorage use segmented append-only file, all data in disk, all index in memory.
@@ -180,6 +191,7 @@ public:
 
     // append entries to log and update IOMetric, return success append number
     virtual int append_entries(const std::vector<LogEntry*>& entries, IOMetric* metric);
+    virtual int append_entries_new(const std::vector<LogEntry*>& entries, IOMetric* metric);
 
     // delete logs from storage's head, [1, first_index_kept) will be discarded
     virtual int truncate_prefix(const int64_t first_index_kept);

--- a/src/braft/log_manager.cpp
+++ b/src/braft/log_manager.cpp
@@ -517,9 +517,12 @@ public:
         _size = 0;
         _buffer_size = 0;
     }
+    // TODO(zkl): flush in the outside
     void append(LogManager::StableClosure* done) {
         if (_size == _cap || 
                 _buffer_size >= (size_t)FLAGS_raft_max_append_buffer_size) {
+            // LOG(INFO) << "_size: " << _size << ", _cap: " << _cap << ", _buffer_size: " << _buffer_size
+            //     << ", flush...";
             flush();
         }
         _storage[_size++] = done;
@@ -550,6 +553,8 @@ int LogManager::disk_thread(void* meta,
     // FIXME(chenzhangyi01): it's buggy
     LogId last_id = log_manager->_disk_id;
     StableClosure* storage[256];
+    // StableClosure* storage[1024];
+    // TODO(zkl): change cap
     AppendBatcher ab(storage, ARRAY_SIZE(storage), &last_id, log_manager);
     
     for (; iter; ++iter) {

--- a/src/braft/log_manager.cpp
+++ b/src/braft/log_manager.cpp
@@ -536,6 +536,7 @@ public:
                 _dynamic_storage[i]->Run();
                 // run_ns << butil::cpuwide_time_ns() - start;
             }
+            _dynamic_storage.clear();
             _to_append.clear();
         }
         _size = 0;

--- a/src/braft/log_manager.cpp
+++ b/src/braft/log_manager.cpp
@@ -28,7 +28,7 @@
 
 DEFINE_bool(log_storage_append_entries_in_batch,
     false, "log storage append entries in batch using writev");
-DEFINE_int32(append_batcher_capacity, 256, "AppendBatcher capacity");
+// DEFINE_int32(append_batcher_capacity, 256, "AppendBatcher capacity");
 DEFINE_bool(unlimit_append_batcher, false, "unlimit append batcher");
 
 namespace braft {

--- a/src/braft/log_manager.cpp
+++ b/src/braft/log_manager.cpp
@@ -26,7 +26,8 @@
 #include "braft/fsm_caller.h"                    // FSMCaller
 
 
-DEFINE_bool(use_new_append_entries, false, "use new append entries");
+DEFINE_bool(log_storage_append_entries_in_batch,
+    false, "log storage append entries in batch using writev");
 DEFINE_int32(append_batcher_capacity, 256, "AppendBatcher capacity");
 DEFINE_bool(unlimit_append_batcher, false, "unlimit append batcher");
 
@@ -461,8 +462,8 @@ void LogManager::append_to_storage(std::vector<LogEntry*>* to_append,
         butil::Timer timer;
         timer.start();
         g_storage_append_entries_concurrency << 1;
-        int nappent = FLAGS_use_new_append_entries ?
-            _log_storage->append_entries_new(*to_append, metric) :_log_storage->append_entries(*to_append, metric);
+        int nappent = FLAGS_log_storage_append_entries_in_batch ?
+            _log_storage->append_entries_in_batch(*to_append, metric) :_log_storage->append_entries(*to_append, metric);
         g_storage_append_entries_concurrency << -1;
         timer.stop();
         if (nappent != (int)to_append->size()) {

--- a/src/braft/memory_log.cpp
+++ b/src/braft/memory_log.cpp
@@ -83,7 +83,7 @@ int MemoryLogStorage::append_entries(const std::vector<LogEntry*>& entries,
     return entries.size();
 }
 
-int MemoryLogStorage::append_entries_new(const std::vector<LogEntry*>& entries,
+int MemoryLogStorage::append_entries_in_batch(const std::vector<LogEntry*>& entries,
                                          IOMetric* metric) {
     if (entries.empty()) {
         return 0;

--- a/src/braft/memory_log.cpp
+++ b/src/braft/memory_log.cpp
@@ -83,6 +83,18 @@ int MemoryLogStorage::append_entries(const std::vector<LogEntry*>& entries,
     return entries.size();
 }
 
+int MemoryLogStorage::append_entries_new(const std::vector<LogEntry*>& entries,
+                                         IOMetric* metric) {
+    if (entries.empty()) {
+        return 0;
+    }
+    for (size_t i = 0; i < entries.size(); i++) {
+        LogEntry* entry = entries[i];
+        append_entry(entry);
+    }
+    return entries.size();
+}
+
 int MemoryLogStorage::truncate_prefix(const int64_t first_index_kept) {
     std::deque<LogEntry*> popped;
     std::unique_lock<raft_mutex_t> lck(_mutex);

--- a/src/braft/memory_log.h
+++ b/src/braft/memory_log.h
@@ -66,6 +66,8 @@ public:
     // append entries to log and update IOMetric, return append success number 
     virtual int append_entries(const std::vector<LogEntry*>& entries, IOMetric* metric);
 
+    virtual int append_entries_new(const std::vector<LogEntry*>& entries, IOMetric* metric);
+
     // delete logs from storage's head, [first_log_index, first_index_kept) will be discarded
     virtual int truncate_prefix(const int64_t first_index_kept);
 

--- a/src/braft/memory_log.h
+++ b/src/braft/memory_log.h
@@ -66,7 +66,7 @@ public:
     // append entries to log and update IOMetric, return append success number 
     virtual int append_entries(const std::vector<LogEntry*>& entries, IOMetric* metric);
 
-    virtual int append_entries_new(const std::vector<LogEntry*>& entries, IOMetric* metric);
+    virtual int append_entries_in_batch(const std::vector<LogEntry*>& entries, IOMetric* metric);
 
     // delete logs from storage's head, [first_log_index, first_index_kept) will be discarded
     virtual int truncate_prefix(const int64_t first_index_kept);

--- a/src/braft/storage.h
+++ b/src/braft/storage.h
@@ -145,7 +145,7 @@ public:
 
     // append entries to log and update IOMetric, return append success number 
     virtual int append_entries(const std::vector<LogEntry*>& entries, IOMetric* metric) = 0;
-    virtual int append_entries_new(const std::vector<LogEntry*>& entries, IOMetric* metric) = 0;
+    virtual int append_entries_in_batch(const std::vector<LogEntry*>& entries, IOMetric* metric) = 0;
 
     // delete logs from storage's head, [first_log_index, first_index_kept) will be discarded
     virtual int truncate_prefix(const int64_t first_index_kept) = 0;

--- a/src/braft/storage.h
+++ b/src/braft/storage.h
@@ -145,6 +145,7 @@ public:
 
     // append entries to log and update IOMetric, return append success number 
     virtual int append_entries(const std::vector<LogEntry*>& entries, IOMetric* metric) = 0;
+    virtual int append_entries_new(const std::vector<LogEntry*>& entries, IOMetric* metric) = 0;
 
     // delete logs from storage's head, [first_log_index, first_index_kept) will be discarded
     virtual int truncate_prefix(const int64_t first_index_kept) = 0;


### PR DESCRIPTION
* Prepare the batch data and use `writev` instead of calling `write` for each entry;
   write log benchmark shows qps increase from **13w to 17w** when log data size is 100 bytes, and **4.9w to 5.8w** for log data size is 1024 bytes.
   enable by flag `-log_storage_append_entries_in_batch=1`.
* Added flag `unlimit_append_batcher` which removes the batch size limit when writing data to disk;
  write log benchmark shows qps increase **from 18w to 23.7w** when log data size is 100 bytes, and **5.7w to 17w** when log data size is 1024 bytes. `log_storage_append_entries_in_batch` is also set when benchmarking.
  enable by flag `-unlimit_append_batcher=1`.
* [TODO] Add flag to increase the AppendBatcher batch to increase the throughput.